### PR TITLE
Add Hatch build backend to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,7 @@ ignore = ["D101", "D102", "D107", "D103", "D203", "D212", "D203", "D212", "D100"
 
 [tool.setuptools.package-data]
 niche_elf = ["py.typed"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"


### PR DESCRIPTION
Add Hatch as the build backend like `pwndbg` [here](https://github.com/pwndbg/pwndbg/blob/2026.02.18/pyproject.toml#L184) so the project can be more readily packaged given that it's a dependency for the latest `pwndbg` release.